### PR TITLE
Rename "private" to "management"

### DIFF
--- a/.circleci/.env.circleci
+++ b/.circleci/.env.circleci
@@ -10,4 +10,4 @@ SS_DEFAULT_ADMIN_PASSWORD=password
 SS_ERROR_LOG="silverstripe.log"
 BIFROST_ENDPOINT="http://localhost"
 BIFROST_ENGINE_PREFIX="search-engine-main"
-BIFROST_PRIVATE_API_KEY="bifrost_private_key"
+BIFROST_MANAGEMENT_API_KEY="bifrost_private_key"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ private API key.
 ```
 BIFROST_ENDPOINT="https://abc123.app-search.ap-southeast-2.aws.found.io:443"
 BIFROST_ENGINE_PREFIX="index-name-excluding-variant"
-BIFROST_PRIVATE_API_KEY="APIKEY123"
+BIFROST_MANAGEMENT_API_KEY="APIKEY123"
 ```
 
 ## Configuration

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,7 @@
 ---
 Name: search-service-bifrost
 Only:
-  envvarset: 'BIFROST_PRIVATE_API_KEY'
+  envvarset: 'BIFROST_MANAGEMENT_API_KEY'
 After:
   - 'silverstripe-search-service-dataobject'
   - 'search-service-default'
@@ -20,7 +20,7 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\SearchServiceBifrost\Service\ClientFactory
     constructor:
       host: '`BIFROST_ENDPOINT`'
-      token: '`BIFROST_PRIVATE_API_KEY`'
+      token: '`BIFROST_MANAGEMENT_API_KEY`'
       http_client: '%$GuzzleHttp\Client'
   Elastic\EnterpriseSearch\AppSearch\Request\GetSchema:
     class: SilverStripe\SearchServiceBifrost\Service\Requests\GetSchema

--- a/src/Service/ClientFactory.php
+++ b/src/Service/ClientFactory.php
@@ -21,7 +21,7 @@ class ClientFactory implements Factory
         if (!$host || !$token) {
             throw new Exception(sprintf(
                 'The %s implementation requires environment variables: ' .
-                'BIFROST_ENDPOINT and BIFROST_PRIVATE_API_KEY',
+                'BIFROST_ENDPOINT and BIFROST_MANAGEMENT_API_KEY',
                 Client::class
             ));
         }


### PR DESCRIPTION
To remove confusion between this and encryption keys private/public (which, is probably what most folks think of when they think of "private" keys).