### PR TITLE
Update GetEngines to PostEngines to allow for body content

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -33,7 +33,7 @@ SilverStripe\Core\Injector\Injector:
   Elastic\EnterpriseSearch\AppSearch\Request\ListDocuments:
     class: SilverStripe\ForagerBifrost\Service\Requests\PostDocumentsList
   Elastic\EnterpriseSearch\AppSearch\Request\ListEngines:
-    class: SilverStripe\ForagerBifrost\Service\Requests\GetEngines
+    class: SilverStripe\ForagerBifrost\Service\Requests\PostEngines
   Elastic\EnterpriseSearch\AppSearch\Request\PutSchema:
     class: SilverStripe\ForagerBifrost\Service\Requests\PostSchema
 

--- a/src/Service/Requests/PostEngines.php
+++ b/src/Service/Requests/PostEngines.php
@@ -4,13 +4,14 @@ namespace SilverStripe\ForagerBifrost\Service\Requests;
 
 use Elastic\EnterpriseSearch\AppSearch\Request\ListEngines as AppSearchListEngines;
 
-class GetEngines extends AppSearchListEngines
+class PostEngines extends AppSearchListEngines
 {
 
     public function __construct()
     {
         parent::__construct();
 
+        $this->method = 'POST';
         $this->path = '/api/v1/engines';
     }
 


### PR DESCRIPTION
I had a quick skim through the other Request classes in the EC SDK that use `method = 'GET"`.

These two we now have both covered by switching them to `POST` requests:

* ListDocuments
* ListEngines

These two we might have to keep in mind in the future, but for now, we don't care:

* ListSysnonymSets
* ListCurations

These ones we might never care to implement:

* ListApiKeys
* ListCrawlerCrawlRequests
* ListCrawlerDomains
* ListCrawlerProcessCrawls
