### PR TITLE
Add suffix to Client configuration yaml

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -13,10 +13,10 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Forager\Interfaces\IndexingInterface:
     class: SilverStripe\ForagerBifrost\Service\BifrostService
     constructor:
-      client: '%$Elastic\EnterpriseSearch\Client'
+      client: '%$Elastic\EnterpriseSearch\Client.managementClient'
       configuration: '%$SilverStripe\Forager\Service\IndexConfiguration'
       builder: '%$SilverStripe\Forager\Service\DocumentBuilder'
-  Elastic\EnterpriseSearch\Client:
+  Elastic\EnterpriseSearch\Client.managementClient:
     factory: SilverStripe\ForagerBifrost\Service\ClientFactory
     constructor:
       host: '`BIFROST_ENDPOINT`'


### PR DESCRIPTION
The Discoverer modules uses the configuration name `%$Elastic\EnterpriseSearch\Client.searchClient`, but when I was testing some recent changes I noticed that the Forager client (from this module - that doesn't have a suffix) was being invoked instead of the Discoverer client.

I'm not sure if this is a new framework issue, but the immediate way to resolve this is to make sure that both modules have their own suffix when instantiating the ES Client.

This would technically be a breaking change if someone has implemented their own version of this configuration, but I think the chances of that are low, and I'm inclined to call this a bugfix.