### PR TITLE
Add extension to log detail for client errors

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -10,3 +10,12 @@ SilverStripe\Assets\File:
 SilverStripe\AssetAdmin\Forms\FileFormFactory:
   extensions:
     ForagerBifrostFileFormExtension: SilverStripe\ForagerBifrost\Extensions\FileFormExtension
+
+---
+Name: 'forager-bifrost-extensions-queuedjobs'
+Only:
+  moduleexists: 'symbiote/silverstripe-queuedjobs'
+---
+Symbiote\QueuedJobs\Services\QueuedJobService:
+  extensions:
+    ForagerBifrostQueuedJobsExtension: SilverStripe\ForagerBifrost\Extensions\QueuedJobsExtension

--- a/src/Extensions/QueuedJobsExtension.php
+++ b/src/Extensions/QueuedJobsExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\ForagerBifrost\Extensions;
+
+use SilverStripe\Core\Extension;
+use Silverstripe\Search\Client\Exception\ClientException;
+use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+use Throwable;
+
+class QueuedJobsExtension extends Extension
+{
+
+    /**
+     * Log response body for search client errors in queued jobs
+     *
+     * @param QueuedJobDescriptor $jobDescriptor
+     * @param QueuedJob $job
+     * @param Throwable $e
+     * @return void
+     */
+    public function updateJobDescriptorAndJobOnException(
+        QueuedJobDescriptor $jobDescriptor,
+        QueuedJob $job,
+        Throwable $e
+    ): void {
+        if (!$e instanceof ClientException) {
+            return;
+        }
+
+        if (!method_exists($e, 'getResponse')) {
+            return;
+        }
+
+        $job->addMessage(json_encode(['ApiResponse' => (string) $e->getResponse()->getBody()]), 'ERROR');
+    }
+
+}


### PR DESCRIPTION
hopefully will help with errors. An example in job messages would look like:

```
[2025-08-05 10:43:18][ERROR] {"ApiResponse":"{\"detail\":[{\"type\":\"missing\",\"loc\":[\"body\"],\"msg\":\"Field required\",\"input\":null}]}"}
[2025-08-05 10:43:18][WARNING] Job paused at 2025-08-05 10:43:18 [] []
[2025-08-05 10:43:18][ERROR] Validation Error {"exception":"[object] (Silverstripe\\Search\\Client\\Exception\\DocumentsDeleteUnprocessableEntityException(code: 422): Validation Error at /var/www/html/vendor/silverstripe/silverstripe-search-client-php/src/Endpoint/DocumentsDelete.php:59)"} []
```