### PR TITLE
AOS-294: Forager Bifrost > Document search extraction limit could be worded better

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,4 +1,4 @@
 en:
   SilverStripe\ForagerBifrost\Extensions\FileFormExtension:
     FILE_LIMIT_MESSAGE: "Document search extraction limit is {limit}"
-    LARGE_FILE_WARNING: "File size is {size} which exceeds the search extraction limit of {limit}"
+    LARGE_FILE_WARNING: "Text contained within this {size} file cannot be indexed for search. The file size limit for text extraction is {limit}."

--- a/src/Extensions/FileFormExtension.php
+++ b/src/Extensions/FileFormExtension.php
@@ -78,7 +78,8 @@ class FileFormExtension extends Extension
                     ['class' => 'alert alert-warning'],
                     _t(
                         self::class . '.LARGE_FILE_WARNING',
-                        'Text contained within this {size} file cannot be indexed for search. The file size limit for text extraction is {limit}.',
+                        'Text contained within this {size} file cannot be indexed for search. '
+                            . 'The file size limit for text extraction is {limit}.',
                         [
                             'size' => $file->getSize(),
                             'limit' => SearchFile::sizeLimit(),

--- a/src/Extensions/FileFormExtension.php
+++ b/src/Extensions/FileFormExtension.php
@@ -78,7 +78,7 @@ class FileFormExtension extends Extension
                     ['class' => 'alert alert-warning'],
                     _t(
                         self::class . '.LARGE_FILE_WARNING',
-                        'File size is {size} which exceeds the search extraction limit of {limit}',
+                        'Text contained within this {size} file cannot be indexed for search. The file size limit for text extraction is {limit}.',
                         [
                             'size' => $file->getSize(),
                             'limit' => SearchFile::sizeLimit(),

--- a/tests/Extensions/FileFormExtensionTest.php
+++ b/tests/Extensions/FileFormExtensionTest.php
@@ -139,7 +139,8 @@ class FileFormExtensionTest extends SapphireTest
 
         $this->assertInstanceOf(LiteralField::class, $field);
         $this->assertEquals(
-            '<p class="alert alert-warning">File size is 16 MB which exceeds the search extraction limit of 15 MB</p>',
+            '<p class="alert alert-warning">Text contained within this 16 MB file cannot be indexed for search.'
+                . ' The file size limit for text extraction is 15 MB.</p>',
             $field->getContent()
         );
     }


### PR DESCRIPTION
# Jira ticket
[AOS-294 Forager Bifrost > Document search extraction limit could be worded better](https://silverstripe.atlassian.net/browse/AOS-294)

# Description

Updated the alert message for files above the limit for text extraction.

(I've verified that for the above case, the app simply returns an error rather than do anything fancy like extract first 15Mb).

Before:
<img width="460" height="417" alt="Screenshot 2025-08-15 at 10 10 18 AM" src="https://github.com/user-attachments/assets/a478eb22-8b64-4e09-ac83-5692eadfee52" />

After:
<img width="522" height="482" alt="Screenshot 2025-08-15 at 10 45 51 AM" src="https://github.com/user-attachments/assets/a7dddc95-ef9a-481a-b898-b53a13474f52" />

