### PR TITLE
AOS-295: large document report visibility

### DIFF
--- a/src/Reports/LargeDocumentReport.php
+++ b/src/Reports/LargeDocumentReport.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ForagerBifrost\Reports;
 
 use SilverStripe\Assets\File;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
+use SilverStripe\ForagerBifrost\Extensions\FileExtension;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Reports\Report;
 
@@ -21,6 +22,10 @@ class LargeDocumentReport extends Report
 
     public function description(): string
     {
+        if (!$this->isReportActive()) {
+            return 'This report requires the SEARCH_INDEX_FILES environment variable and file extension.';
+        }
+
         return sprintf(
             $this->description,
             SearchFile::sizeLimit()
@@ -42,6 +47,22 @@ class LargeDocumentReport extends Report
         return File::get()
             ->filter(['ContentSize:GreaterThan' => SearchFile::SIZE_LIMIT])
             ->sort(['Created' => 'DESC']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canView($member = null): bool
+    {
+        return $this->isReportActive();
+    }
+
+    /**
+     * This report can only be active if the required extension is enabled
+     */
+    private function isReportActive(): bool
+    {
+        return File::has_extension(FileExtension::class);
     }
 
 }

--- a/tests/Reports/LargeDocumentReportTest.php
+++ b/tests/Reports/LargeDocumentReportTest.php
@@ -34,6 +34,13 @@ class LargeDocumentReportTest extends SapphireTest
             'Documents excluded for content ingestion in Silverstripe Search which exceeds 15 MB',
             $report->description()
         );
+
+        // Removing extension should result in a new description
+        $this->removeFileExtension();
+        $this->assertEquals(
+            'This report requires the SEARCH_INDEX_FILES environment variable and file extension.',
+            $report->description()
+        );
     }
 
     public function testColumns(): void
@@ -68,6 +75,22 @@ class LargeDocumentReportTest extends SapphireTest
 
         $this->assertCount(1, $files);
         $this->assertEquals($file21MbId, $files->first()->ID);
+    }
+
+    public function testCanView(): void
+    {
+        $report = new LargeDocumentReport();
+
+        $this->assertTrue($report->canView());
+
+        // When the extension is not present on the File then the report should not be viewable
+        $this->removeFileExtension();
+        $this->assertfalse($report->canView());
+    }
+
+    protected function removeFileExtension(): void
+    {
+        File::remove_extension(FileExtension::class);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## Problem

When `SEARCH_INDEX_FILES` is not set the reports model admin will return an error. This is due to the large document report being enabled and trying to access data provided only when `SEARCH_INDEX_FILES` is enabled.

Related issue can be found here:
[Large Document Report issue](https://github.com/silverstripeltd/silverstripe-forager-bifrost/issues/15)

## CanView

Implement a canView check on the large document report that only shows the report when the expected file extension is applied.