### PR TITLE
AOS-295: CMS6 large document report visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ SilverStripe\Forager\Service\IndexConfiguration:
 
 ### File attachments for content extraction
 
-Firstly, you will need to set this environment variable. This will apply an extension to the `File` class, and allow you to use the `_attachment` field (detailed below).
+Firstly, you will need to apply the FileExtension extension onto Files. This extension will allow you to use the `_attachment` field (detailed below).
 
 ```yaml
-SEARCH_INDEX_FILES=1
+SilverStripe\Assets\File:
+    extensions:
+        ForagerBifrostFileExtension: SilverStripe\ForagerBifrost\Extensions\FileExtension
 ```
 
 Silverstripe Search supports content extraction for many different file types. These can be attached to your Documents using an `_attachment` field of type `binary`.

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,10 +1,6 @@
 ---
 Name: forager-bifrost-extensions
 ---
-SilverStripe\Assets\File:
-  extensions:
-    ForagerBifrostFileExtension: SilverStripe\ForagerBifrost\Extensions\FileExtension
-
 SilverStripe\AssetAdmin\Forms\FileFormFactory:
   extensions:
     ForagerBifrostFileFormExtension: SilverStripe\ForagerBifrost\Extensions\FileFormExtension

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,7 +1,5 @@
 ---
 Name: forager-bifrost-extensions
-Only:
-  envvarset: SEARCH_INDEX_FILES
 ---
 SilverStripe\Assets\File:
   extensions:

--- a/src/Extensions/FileExtension.php
+++ b/src/Extensions/FileExtension.php
@@ -7,6 +7,8 @@ use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
 
 /**
@@ -33,6 +35,12 @@ class FileExtension extends Extension
      */
     public function updateSearchAttributes(array &$attributes = []): void
     {
+        $fileClass = Injector::inst()->get(File::class);
+
+        if (!$fileClass->hasExtension(SearchServiceExtension::class)) {
+            return;
+        }
+
         if (!isset($attributes['_attachment'])) {
             return;
         }
@@ -60,6 +68,12 @@ class FileExtension extends Extension
 
     public function onBeforeWrite(): void
     {
+        $fileClass = Injector::inst()->get(File::class);
+
+        if (!$fileClass->hasExtension(SearchServiceExtension::class)) {
+            return;
+        }
+
         $file = $this->getOwner();
 
         // Marks images and folders with zero content to exclude them from report generation

--- a/src/Extensions/FileExtension.php
+++ b/src/Extensions/FileExtension.php
@@ -7,8 +7,6 @@ use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
 
 /**
@@ -35,12 +33,6 @@ class FileExtension extends Extension
      */
     public function updateSearchAttributes(array &$attributes = []): void
     {
-        $fileClass = Injector::inst()->get(File::class);
-
-        if (!$fileClass->hasExtension(SearchServiceExtension::class)) {
-            return;
-        }
-
         if (!isset($attributes['_attachment'])) {
             return;
         }
@@ -68,12 +60,6 @@ class FileExtension extends Extension
 
     public function onBeforeWrite(): void
     {
-        $fileClass = Injector::inst()->get(File::class);
-
-        if (!$fileClass->hasExtension(SearchServiceExtension::class)) {
-            return;
-        }
-
         $file = $this->getOwner();
 
         // Marks images and folders with zero content to exclude them from report generation

--- a/src/Extensions/FileFormExtension.php
+++ b/src/Extensions/FileFormExtension.php
@@ -6,6 +6,8 @@ use SilverStripe\Assets\File;
 use SilverStripe\Assets\Image;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -27,6 +29,12 @@ class FileFormExtension extends Extension
         string $name = FormFactory::DEFAULT_NAME,
         array $context = []
     ): void {
+        $fileClass = Injector::inst()->get(File::class);
+
+        if (!$fileClass->hasExtension(SearchServiceExtension::class)) {
+            return;
+        }
+
         /** @var FieldList $fields */
         $fields = $form->Fields()->fieldByName('Editor.Details');
         $file = $context['Record'] ?? null;
@@ -79,7 +87,7 @@ class FileFormExtension extends Extension
                     _t(
                         self::class . '.LARGE_FILE_WARNING',
                         'Text contained within this {size} file cannot be indexed for search. '
-                            . 'The file size limit for text extraction is {limit}.',
+                        . 'The file size limit for text extraction is {limit}.',
                         [
                             'size' => $file->getSize(),
                             'limit' => SearchFile::sizeLimit(),

--- a/src/Extensions/FileFormExtension.php
+++ b/src/Extensions/FileFormExtension.php
@@ -7,7 +7,6 @@ use SilverStripe\Assets\Image;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -31,7 +30,7 @@ class FileFormExtension extends Extension
     ): void {
         $fileClass = Injector::inst()->get(File::class);
 
-        if (!$fileClass->hasExtension(SearchServiceExtension::class)) {
+        if (!$fileClass->hasExtension(FileExtension::class)) {
             return;
         }
 

--- a/src/Reports/LargeDocumentReport.php
+++ b/src/Reports/LargeDocumentReport.php
@@ -4,8 +4,8 @@ namespace SilverStripe\ForagerBifrost\Reports;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
+use SilverStripe\ForagerBifrost\Extensions\FileExtension;
 use SilverStripe\Model\List\SS_List;
 use SilverStripe\Reports\Report;
 
@@ -24,7 +24,7 @@ class LargeDocumentReport extends Report
     public function description(): string
     {
         if (!$this->isReportActive()) {
-            return 'This report requires the SearchServiceExtension being applied to Files.';
+            return 'This report requires the FileExtension being applied to Files.';
         }
 
         return sprintf(
@@ -65,7 +65,7 @@ class LargeDocumentReport extends Report
     {
         $fileClass = Injector::inst()->get(File::class);
 
-        return $fileClass->has_extension(SearchServiceExtension::class);
+        return $fileClass->has_extension(FileExtension::class);
     }
 
 }

--- a/src/Reports/LargeDocumentReport.php
+++ b/src/Reports/LargeDocumentReport.php
@@ -3,6 +3,8 @@
 namespace SilverStripe\ForagerBifrost\Reports;
 
 use SilverStripe\Assets\File;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Constants\SearchFile;
 use SilverStripe\Model\List\SS_List;
 use SilverStripe\Reports\Report;
@@ -21,6 +23,10 @@ class LargeDocumentReport extends Report
 
     public function description(): string
     {
+        if (!$this->isReportActive()) {
+            return 'This report requires the SEARCH_INDEX_FILES environment variable and file extension.';
+        }
+
         return sprintf(
             $this->description,
             SearchFile::sizeLimit()
@@ -42,6 +48,24 @@ class LargeDocumentReport extends Report
         return File::get()
             ->filter(['ContentSize:GreaterThan' => SearchFile::SIZE_LIMIT])
             ->sort(['Created' => 'DESC']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canView($member = null): bool
+    {
+        return $this->isReportActive();
+    }
+
+    /**
+     * This report can only be active if the required extension is enabled
+     */
+    private function isReportActive(): bool
+    {
+        $fileClass = Injector::inst()->get(File::class);
+
+        return $fileClass->has_extension(SearchServiceExtension::class);
     }
 
 }

--- a/src/Reports/LargeDocumentReport.php
+++ b/src/Reports/LargeDocumentReport.php
@@ -24,7 +24,7 @@ class LargeDocumentReport extends Report
     public function description(): string
     {
         if (!$this->isReportActive()) {
-            return 'This report requires the SEARCH_INDEX_FILES environment variable and file extension.';
+            return 'This report requires the SearchServiceExtension being applied to Files.';
         }
 
         return sprintf(

--- a/tests/Extensions/FileExtensionTest.php
+++ b/tests/Extensions/FileExtensionTest.php
@@ -5,7 +5,6 @@ namespace SilverStripe\ForagerBifrost\Tests\Extensions;
 use SilverStripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
-use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Extensions\FileExtension;

--- a/tests/Extensions/FileExtensionTest.php
+++ b/tests/Extensions/FileExtensionTest.php
@@ -102,7 +102,6 @@ class FileExtensionTest extends SapphireTest
         parent::setUp();
 
         TestAssetStore::activate('SearchFileTest');
-        Environment::setEnv('SEARCH_INDEX_FILES', 1);
     }
 
     protected function tearDown(): void

--- a/tests/Reports/LargeDocumentReportTest.php
+++ b/tests/Reports/LargeDocumentReportTest.php
@@ -4,7 +4,6 @@ namespace SilverStripe\ForagerBifrost\Tests\Reports;
 
 use SilverStripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
-use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forager\Extensions\SearchServiceExtension;
 use SilverStripe\ForagerBifrost\Extensions\FileExtension;
@@ -38,7 +37,7 @@ class LargeDocumentReportTest extends SapphireTest
         // Removing extension should result in a new description
         $this->removeFileExtension();
         $this->assertEquals(
-            'This report requires the SearchServiceExtension being applied to Files.',
+            'This report requires the FileExtension being applied to Files.',
             $report->description()
         );
 
@@ -91,7 +90,7 @@ class LargeDocumentReportTest extends SapphireTest
 
     protected function removeFileExtension(): void
     {
-        File::remove_extension(SearchServiceExtension::class);
+        File::remove_extension(FileExtension::class);
     }
 
     protected function setUp(): void

--- a/tests/Reports/LargeDocumentReportTest.php
+++ b/tests/Reports/LargeDocumentReportTest.php
@@ -38,7 +38,7 @@ class LargeDocumentReportTest extends SapphireTest
         // Removing extension should result in a new description
         $this->removeFileExtension();
         $this->assertEquals(
-            'This report requires the SEARCH_INDEX_FILES environment variable and file extension.',
+            'This report requires the SearchServiceExtension being applied to Files.',
             $report->description()
         );
 

--- a/tests/Reports/LargeDocumentReportTest.php
+++ b/tests/Reports/LargeDocumentReportTest.php
@@ -34,6 +34,25 @@ class LargeDocumentReportTest extends SapphireTest
             'Documents excluded for content ingestion in Silverstripe Search which exceeds 15 MB',
             $report->description()
         );
+
+        // Removing extension should result in a new description
+        $this->removeFileExtension();
+        $this->assertEquals(
+            'This report requires the SEARCH_INDEX_FILES environment variable and file extension.',
+            $report->description()
+        );
+
+    }
+
+    public function testCanView(): void
+    {
+        $report = new LargeDocumentReport();
+
+        $this->assertTrue($report->canView());
+
+        // When the extension is not present on the File then the report should not be viewable
+        $this->removeFileExtension();
+        $this->assertfalse($report->canView());
     }
 
     public function testColumns(): void
@@ -70,12 +89,16 @@ class LargeDocumentReportTest extends SapphireTest
         $this->assertEquals($file21MbId, $files->first()->ID);
     }
 
+    protected function removeFileExtension(): void
+    {
+        File::remove_extension(SearchServiceExtension::class);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
 
         TestAssetStore::activate('SearchFileTest');
-        Environment::setEnv('SEARCH_INDEX_FILES', 1);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
CMS6 support for handling large document report where there is no longer SEARCH_INDEX_FILES and relies on the File class having the SearchServiceExtension applied.

https://github.com/silverstripeltd/silverstripe-forager-bifrost/issues/15